### PR TITLE
Benchmarks with criterion for the load balancer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,10 +138,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "color-eyre"
@@ -157,6 +227,70 @@ dependencies = [
  "tracing-core",
  "tracing-error",
 ]
+
+[[package]]
+name = "criterion"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf7af66b0989381bd0be551bd7cc91912a655a58c6918420c9527b1fd8b4679"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "displaydoc"
@@ -306,6 +440,16 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "heck"
@@ -534,6 +678,24 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -581,9 +743,10 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "color-eyre",
+ "criterion",
  "futures",
  "http",
- "itertools",
+ "itertools 0.14.0",
  "rand",
  "reqwest",
  "serde",
@@ -674,6 +837,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,6 +859,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "overload"
@@ -740,6 +918,34 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "potential_utf"
@@ -810,6 +1016,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rayon"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -920,6 +1146,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1118,6 +1353,16 @@ checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1328,6 +1573,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1715,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +588,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tokio",
  "tower",
@@ -1021,6 +1029,25 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,16 @@ reqwest = { version = "0.12.18", default-features = false, features = [
 thiserror = "2.0.12"
 http = "*"
 rand = "0.9.1"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive", "rc"] }
 serde_json = "1.0"
 itertools = "0.14.0"
 futures = "0.3.31"
+strum = "0.27.1"
+strum_macros = "0.27.1"
+
+# [dev-dependencies]
+# criterion = { version = "0.6", features = ["html_reports"] }
+#
+# [[bench]]
+# name = "bench_balancing_strategies"
+# harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,9 +30,9 @@ futures = "0.3.31"
 strum = "0.27.1"
 strum_macros = "0.27.1"
 
-# [dev-dependencies]
-# criterion = { version = "0.6", features = ["html_reports"] }
-#
-# [[bench]]
-# name = "bench_balancing_strategies"
-# harness = false
+[dev-dependencies]
+criterion = { version = "0.6", features = ["html_reports"] }
+
+[[bench]]
+name = "bench_balancing_strategies"
+harness = false

--- a/benches/bench_balancing_strategies.rs
+++ b/benches/bench_balancing_strategies.rs
@@ -1,0 +1,190 @@
+#![allow(unused)]
+
+use std::{sync::Arc, time::Duration};
+
+use criterion::{Criterion, criterion_group, criterion_main};
+use futures::future::join_all;
+use load_balancer::{
+    load_balancer::{
+        balancing_strategy::BalancingStrategy,
+        server::{LoadBalancer, SetBalancingStrategyRequest},
+    },
+    worker::{self, WorkerConfig, WorkerServer},
+};
+use serde_json::json;
+use tokio::{sync::Mutex, task::JoinSet};
+
+// Number of worker servers available
+static NB_WORKERS: u32 = 10;
+// Number of requests sent to the load balancer
+static NB_REQUESTS: u64 = 1;
+// If the work duration is not set, pick a random value within thi srange
+static RANDOM_WORK_DURATION_RANGE: std::ops::Range<u64> = 0..2000;
+// The time the worker server spends on working
+static WORK_DURATION_MS: u64 = 1000;
+// IP of the load balancer
+static IP: &'static str = "127.0.0.1";
+
+criterion_group!(benches, bench_balancing_strategies);
+criterion_main!(benches);
+
+fn bench_balancing_strategies(c: &mut Criterion) {
+    load_balancer::tracing::init_tracing().expect("Failed to init tracing");
+    let nb_requests = NB_REQUESTS;
+
+    let rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Start the load balancer and worker servers
+    let lb_address = rt.block_on(setup_workers_and_lb());
+
+    // Benchmarks where the work duration of requests are constants
+    let mut group = c.benchmark_group("Balancing Strategies with constant work duration");
+    group.bench_function("random", |b| {
+        b.iter(|| {
+            let lb = (&lb_address).clone();
+            rt.block_on(async move {
+                send_requests_to_load_balancer(
+                    lb,
+                    nb_requests,
+                    Some(WORK_DURATION_MS),
+                    BalancingStrategy::Random,
+                )
+            });
+        })
+    });
+    group.bench_function("round robin", |b| {
+        b.iter(|| {
+            let lb = (&lb_address).clone();
+            rt.block_on(async move {
+                send_requests_to_load_balancer(
+                    lb,
+                    nb_requests,
+                    Some(WORK_DURATION_MS),
+                    BalancingStrategy::RoundRobin(Arc::new(Mutex::new(None))),
+                )
+            });
+        })
+    });
+    group.bench_function("least connection", |b| {
+        b.iter(|| {
+            let lb = (&lb_address).clone();
+            rt.block_on(async move {
+                send_requests_to_load_balancer(
+                    lb,
+                    nb_requests,
+                    Some(WORK_DURATION_MS),
+                    BalancingStrategy::LeastConnection,
+                )
+            })
+        })
+    });
+
+    group.finish();
+
+    // Benchmarks where the work duration of requests are random
+    let mut group = c.benchmark_group("Balancing Strategies with random work duration");
+    group.bench_function("random", |b| {
+        b.iter(|| {
+            let lb = (&lb_address).clone();
+            rt.block_on(async move {
+                send_requests_to_load_balancer(lb, nb_requests, None, BalancingStrategy::Random)
+            });
+        })
+    });
+    group.bench_function("round robin", |b| {
+        b.iter(|| {
+            let lb = (&lb_address).clone();
+            rt.block_on(async move {
+                send_requests_to_load_balancer(
+                    lb,
+                    nb_requests,
+                    None,
+                    BalancingStrategy::RoundRobin(Arc::new(Mutex::new(None))),
+                )
+            });
+        })
+    });
+    group.bench_function("least connection", |b| {
+        b.iter(|| {
+            let lb = (&lb_address).clone();
+            rt.block_on(async move {
+                send_requests_to_load_balancer(
+                    lb,
+                    nb_requests,
+                    None,
+                    BalancingStrategy::LeastConnection,
+                )
+            })
+        })
+    });
+
+    group.finish();
+}
+
+async fn setup_workers_and_lb() -> String {
+    // Start all worker servers
+    let workers_setup =
+        join_all((0..NB_WORKERS).map(|_| async { WorkerServer::create_and_run_worker().await }));
+    let workers = workers_setup.await;
+
+    // Start load balancer
+    let address = format!("{}:0", IP);
+    let load_balancer = LoadBalancer::build(&address, workers, None).await.unwrap();
+    let address = load_balancer.address.clone();
+    tokio::spawn(load_balancer.run());
+    address
+}
+
+// Setup the loadbalancer with the provided strategy then send `nb_requests` requests
+// at the "/work" endpoint
+// If work duration is None then picks a random value
+async fn send_requests_to_load_balancer(
+    load_balancer_address: String,
+    nb_requests: u64,
+    work_duration: Option<u64>,
+    strategy: BalancingStrategy,
+) {
+    // reqwuest http client to send request to the load balancer
+    let http_client = reqwest::Client::builder()
+        .build()
+        .expect("Failed to build HTTP client");
+
+    // Set the load balancer strategy for this bench
+    let lb_address = load_balancer_address.clone();
+    let json = json!(SetBalancingStrategyRequest { strategy });
+    let response = &http_client
+        .post(&format!("http://{}/balancing-strategy", lb_address))
+        .json(&json)
+        .send()
+        .await
+        .expect("Failed to execute request");
+
+    // Send requests as a `JoinSet` to wait for all of them
+    let mut requests = JoinSet::new();
+    for _ in 0..nb_requests {
+        // Pick a random work duration if it's set to None
+        let work_duration =
+            work_duration.unwrap_or_else(|| rand::random_range(RANDOM_WORK_DURATION_RANGE.clone()));
+        let lb_address = load_balancer_address.clone();
+        let client = http_client.clone();
+
+        // Send a request to the load balancer
+        requests.spawn(async move {
+            let json = json!({
+                "duration": work_duration,
+            });
+            let response = client
+                .post(&format!("http://{}/work", &lb_address))
+                .json(&json)
+                .send()
+                .await
+                .expect("Failed to execute request");
+            assert_eq!(response.status().as_u16(), 200);
+        });
+    }
+    // Wait for all requests to finish
+    requests.join_all();
+}

--- a/benches/bench_balancing_strategies.rs
+++ b/benches/bench_balancing_strategies.rs
@@ -29,7 +29,7 @@ criterion_group!(benches, bench_balancing_strategies);
 criterion_main!(benches);
 
 fn bench_balancing_strategies(c: &mut Criterion) {
-    load_balancer::tracing::init_tracing().expect("Failed to init tracing");
+    load_balancer::tracing::init_tracing("error").expect("Failed to init tracing");
     let nb_requests = NB_REQUESTS;
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/src/load_balancer/server.rs
+++ b/src/load_balancer/server.rs
@@ -48,7 +48,6 @@ impl LoadBalancer {
             workers,
             strategy: Arc::new(RwLock::new(strategy.unwrap_or_default())),
         };
-        // let server = axum::serve(listener, handle_request.with_state(state));
         let router = LoadBalancer::router(state.clone());
         let server = axum::serve(listener, router);
 

--- a/src/load_balancer/server.rs
+++ b/src/load_balancer/server.rs
@@ -1,18 +1,29 @@
 use crate::load_balancer::balancing_strategy::BalancingStrategy;
 use crate::worker::WorkerConfig;
 use axum::{
+    Json, Router,
     body::Body,
     extract::{Request, State},
-    handler::Handler,
     http::StatusCode,
     response::{IntoResponse, Response},
+    routing::{get, post},
+    serve::Serve,
 };
+use serde::Deserialize;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::{net::TcpListener, sync::RwLock};
 use uuid::Uuid;
 
-pub struct LoadBalancer {}
+pub struct LoadBalancer {
+    #[allow(dead_code)]
+    address: String,
+    server: Serve<TcpListener, Router, Router>,
+    // We don't need lock here since the only field that could be changed
+    // is already behind a lock
+    #[allow(dead_code)]
+    state: LoadBalancerState,
+}
 
 #[derive(Clone, Debug)]
 pub struct LoadBalancerState {
@@ -25,39 +36,74 @@ pub struct LoadBalancerState {
 }
 
 impl LoadBalancer {
-    pub async fn run(
+    pub async fn build(
         addr: &str,
         workers: Vec<WorkerConfig>,
         strategy: Option<BalancingStrategy>,
-    ) -> Result<(), LoadBalancerError> {
+    ) -> Result<Self, LoadBalancerError> {
         let listener = TcpListener::bind(addr).await?;
         let address = listener.local_addr()?.to_string();
-        tracing::info!("Starting load balancer on {}", address);
         let state = LoadBalancerState {
-            address,
+            address: address.clone(),
             workers,
             strategy: Arc::new(RwLock::new(strategy.unwrap_or_default())),
         };
-        let server = axum::serve(listener, handle_request.with_state(state));
-        server.await.map_err(LoadBalancerError::IOError)
+        // let server = axum::serve(listener, handle_request.with_state(state));
+        let router = LoadBalancer::router(state.clone());
+        let server = axum::serve(listener, router);
+
+        Ok(LoadBalancer {
+            address,
+            server,
+            state,
+        })
     }
+
+    pub async fn run(self) -> Result<(), LoadBalancerError> {
+        tracing::info!("Starting load balancer on {}", self.address);
+        self.server.await.map_err(LoadBalancerError::IOError)
+    }
+
+    // To avoid duplication from real implementation and test case
+    fn router(state: LoadBalancerState) -> Router {
+        Router::new()
+            .route("/balancing-strategy", post(set_balancing_strategy))
+            .route("/{*key}", get(transfer_request).post(transfer_request))
+            .with_state(state)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SetBalancingStrategyRequest {
+    strategy: BalancingStrategy,
+}
+
+#[tracing::instrument(skip_all)]
+pub async fn set_balancing_strategy(
+    State(state): State<LoadBalancerState>,
+    Json(request): Json<SetBalancingStrategyRequest>,
+) -> std::result::Result<impl IntoResponse, LoadBalancerError> {
+    let mut s = state.strategy.write().await;
+    *s = request.strategy;
+    Ok(StatusCode::OK)
 }
 
 /// Pick a worker server depending on the balancing strategy chosen and redirect the request to the worker
 #[tracing::instrument(skip_all)]
-pub async fn handle_request(
+pub async fn transfer_request(
     State(state): State<LoadBalancerState>,
     request: Request<Body>,
 ) -> Result<impl IntoResponse, LoadBalancerError> {
     let request_id = Uuid::new_v4();
     tracing::trace!("[{}] received", request_id);
 
-    let chosen_worker = BalancingStrategy::pick_worker(state).await?;
+    let chosen_worker = BalancingStrategy::pick_worker(&state).await?;
     tracing::trace!("[{}] chosen worker {}", request_id, chosen_worker.id);
 
     // Send request to chosen worker
     let request = convert_axum_request_to_reqwest_request(request, chosen_worker);
     tracing::trace!("[{}] request sent {:?}", request_id, request);
+
     let response = reqwest::Client::new()
         .execute(request)
         .await
@@ -111,5 +157,113 @@ impl IntoResponse for LoadBalancerError {
             format!("LoadBalancer error: {}", self),
         )
             .into_response()
+    }
+}
+
+impl LoadBalancer {
+    /// When we need control on the strategy from the outside
+    /// Meant to be used for tests
+    #[cfg(test)]
+    async fn test_run(
+        addr: &str,
+        workers: Vec<WorkerConfig>,
+    ) -> Result<LoadBalancerState, LoadBalancerError> {
+        let load_balancer = LoadBalancer::build(addr, workers, None).await?;
+        let state = load_balancer.state.clone();
+        let _ = tokio::spawn(load_balancer.run());
+        Ok(state)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::worker::{WorkRequest, WorkerServer};
+
+    use super::*;
+    use itertools::Itertools;
+    use rand::seq::IndexedRandom;
+    use serde_json::json;
+    use strum::IntoEnumIterator;
+
+    #[tokio::test]
+
+    async fn worker_requests_are_redirected() {
+        // We start 3 workers
+        let mut workers = vec![];
+        for _ in 0..3 {
+            let worker = WorkerServer::create_and_run_worker().await;
+            workers.push(worker);
+        }
+
+        // We start the loadbalancer
+        let load_balancer_state = LoadBalancer::test_run("127.0.0.1:0", workers.clone())
+            .await
+            .unwrap();
+        let http_client = reqwest::Client::builder()
+            .build()
+            .expect("Failed to build HTTP client");
+
+        // Test the worker different endpoints
+        let get_endpoints = vec!["check-health", "state"];
+        let post_endpoints = vec!["work"];
+
+        for endpoint in get_endpoints {
+            let response = http_client
+                .get(&format!(
+                    "http://{}/{}",
+                    load_balancer_state.address, endpoint
+                ))
+                .send()
+                .await
+                .expect("Failed to execute request");
+            assert_eq!(response.status().as_u16(), 200);
+        }
+
+        for endpoint in post_endpoints {
+            let json = json!(WorkRequest { duration: 1 });
+
+            let response = http_client
+                .post(&format!(
+                    "http://{}/{}",
+                    load_balancer_state.address, endpoint
+                ))
+                .json(&json)
+                .send()
+                .await
+                .expect("Failed to execute request");
+            assert_eq!(response.status().as_u16(), 200);
+        }
+    }
+
+    #[tokio::test]
+    async fn change_strategy_endpoint_works_as_expected() {
+        let workers = WorkerConfig::test_workers(3);
+        let load_balancer_state = LoadBalancer::test_run("127.0.0.1:0", workers.clone())
+            .await
+            .unwrap();
+        let http_client = reqwest::Client::builder()
+            .build()
+            .expect("Failed to build HTTP client");
+
+        let possible_strategies = BalancingStrategy::iter().collect_vec();
+
+        for _ in 0..10 {
+            let strategy = possible_strategies.choose(&mut rand::rng()).unwrap();
+            let json = json!({
+                "strategy": strategy,
+            });
+            let response = http_client
+                .post(&format!(
+                    "http://{}/balancing-strategy",
+                    load_balancer_state.address
+                ))
+                .json(&json)
+                .send()
+                .await
+                .expect("Failed to execute request");
+            assert_eq!(response.status().as_u16(), 200);
+            let lock = load_balancer_state.strategy.read().await;
+            assert_eq!(*strategy, *lock);
+        }
     }
 }

--- a/src/load_balancer/server.rs
+++ b/src/load_balancer/server.rs
@@ -9,7 +9,7 @@ use axum::{
     routing::{get, post},
     serve::Serve,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::{net::TcpListener, sync::RwLock};
@@ -17,12 +17,12 @@ use uuid::Uuid;
 
 pub struct LoadBalancer {
     #[allow(dead_code)]
-    address: String,
+    pub address: String,
     server: Serve<TcpListener, Router, Router>,
     // We don't need lock here since the only field that could be changed
     // is already behind a lock
     #[allow(dead_code)]
-    state: LoadBalancerState,
+    pub state: LoadBalancerState,
 }
 
 #[derive(Clone, Debug)]
@@ -73,9 +73,9 @@ impl LoadBalancer {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct SetBalancingStrategyRequest {
-    strategy: BalancingStrategy,
+#[derive(Debug, Deserialize, Serialize)]
+pub struct SetBalancingStrategyRequest {
+    pub strategy: BalancingStrategy,
 }
 
 #[tracing::instrument(skip_all)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ static IP: &'static str = "127.0.0.1";
 #[tokio::main]
 async fn main() {
     // Tracing
-    init_tracing().expect("Failed to init tracing");
+    init_tracing("error").expect("Failed to init tracing");
 
     // Start workers
     let mut workers = JoinSet::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,12 +30,13 @@ async fn main() {
     }
 
     // Start load balancer
-    LoadBalancer::run(
+    let lb = LoadBalancer::build(
         &format!("{}:3000", IP),
         workers_config,
-        Some(BalancingStrategy::RoundRobin(Arc::new(Mutex::new(0)))),
+        Some(BalancingStrategy::RoundRobin(Arc::new(Mutex::new(None)))),
     )
     .await
-    .expect("Failed to start load balander")
+    .expect("Failed to start load balander");
+    let _ = lb.run().await;
     // workers.join_all().await;
 }

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -4,13 +4,13 @@ use tracing_error::ErrorLayer;
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::prelude::*;
 
-pub fn init_tracing() -> color_eyre::eyre::Result<()> {
+pub fn init_tracing(env_lvl: &str) -> color_eyre::eyre::Result<()> {
     // Create a layer that logs to stdout
     let fmt_layer = tracing_subscriber::fmt::layer().compact();
 
     // Create a layer that filters logs based on the environment variable
     let filter_layer =
-        EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new("trace"))?;
+        EnvFilter::try_from_default_env().or_else(|_| EnvFilter::try_new(env_lvl))?;
 
     tracing_subscriber::registry()
         .with(fmt_layer)

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -34,6 +34,7 @@ pub struct WorkerServer {
 }
 
 pub type WorkerId = u32;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct WorkerConfig {
     pub id: WorkerId,
@@ -112,8 +113,8 @@ pub async fn work(
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct WorkRequest {
-    duration: u64,
+pub(crate) struct WorkRequest {
+    pub(crate) duration: u64,
 }
 
 pub async fn get_worker_state(
@@ -241,6 +242,23 @@ pub(crate) struct DeserializedWorkerState {
     pub(crate) config: WorkerConfig,
     pub(crate) nb_requests_received: u32,
     pub(crate) nb_requests_being_handled: u32,
+}
+
+impl WorkerConfig {
+    // Worker config with random ids
+    #[cfg(test)]
+    pub(crate) fn test_workers(nb_workers: u8) -> Vec<WorkerConfig> {
+        let mut workers = vec![];
+        for _ in 0..nb_workers {
+            let id = rand::rng().random::<u32>();
+
+            workers.push(WorkerConfig {
+                id,
+                address: "127.0.0.1:0".to_string(),
+            });
+        }
+        workers
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Benchmarks to compare performance between balancing strategies: random, round-robin, least-connection

We measure performance in a situation where the load balancer is sent many requests where worker servers are required to "work" for a certain amount of time. 
Two settings:
- Work servers are given constant work duration
- Work servers are given 

__TODO__: Benchmarks are still not working correctly. 
The requests load is  too much for current workbalancer or worker. This is certainly also related to axum not being able too many requests. This needs more investigation